### PR TITLE
Allow custom URL for binary download

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ var nwpath = findpath();
 // nwpath will equal the path to the binary depending on your environment
 ```
 
+## download binaries from custom location
+
+The installer attempts to download binaries from the default location of `http://dl.nwjs.io/v`. You can override this by setting the npm config property `nwjs_urlbase` on the command line by passing the `--nwjs_urlbase` option:
+
+``` shell
+npm install nwjs --nwjs_urlbase=http://my.own.location/somewhere
+```
+
+or adding it to your `.npmrc` file (https://www.npmjs.org/doc/files/npmrc.html):
+
+```
+nwjs_urlbase=http://my.own.location/somewhere
+```
+
+You can alternatively set an environment variable `NWJS_URLBASE`:
+
+``` shell
+export NWJS_URLBASE=http://my.own.location/somewhere
+```
+
 ## using a proxy with or without authentication
 
 If you are behind a proxy server you have to set an environment variable ```http_proxy``` with proxy servers url:

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -17,7 +17,7 @@ if (v.prerelease && typeof v.prerelease[0] === 'string') {
   version += '-' + prerelease.join('-');
 }
 var url = false;
-var urlBase = 'http://dl.nwjs.io/v';
+var urlBase = process.env.npm_config_nwjs_urlbase || process.env.NWJS_URLBASE ||  'http://dl.nwjs.io/v';
 
 // Determine download url
 switch (process.platform) {


### PR DESCRIPTION
Users may wish to download from a custom mirror holding the binaries. This may be for speed or other security restrictions on their local build system. This is very similar to how the installer for phantomjs handles the binary location.