### PR TITLE
install NW.js v0.13.0 alpha 4 SDK build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw",
-  "version": "0.12.3",
+  "version": "0.13.0-alpha4sdk",
   "description": "A installer for nw.js",
   "repository": {
     "type": "git",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -12,6 +12,7 @@ var Decompress = require('decompress');
 var fileExists = require('file-exists');
 var chalk = require('chalk');
 
+var buildSDK = false;
 var v = semver.parse(require('../package.json').version);
 var version = [v.major, v.minor, v.patch].join('.');
 if (v.prerelease && typeof v.prerelease[0] === 'string') {
@@ -21,19 +22,23 @@ if (v.prerelease && typeof v.prerelease[0] === 'string') {
   }
   version += '-' + prerelease.join('-');
 }
+if ( version.slice(-3) === 'sdk' ){
+   version = version.slice(0, -3);
+   buildSDK = true;
+}
 var url = false;
 var urlBase = process.env.npm_config_nwjs_urlbase || process.env.NWJS_URLBASE ||  'http://dl.nwjs.io/v';
 
 // Determine download url
 switch (process.platform) {
   case 'win32':
-    url = urlBase + version + '/nwjs-v' + version + '-win-' + process.arch +'.zip';
+    url = urlBase + version + '/nwjs-' + (buildSDK ? 'sdk-' : '') + 'v' + version + '-win-' + process.arch +'.zip';
     break;
   case 'darwin':
-    url = urlBase + version + '/nwjs-v' + version + '-osx-' + process.arch + '.zip';
+    url = urlBase + version + '/nwjs-' + (buildSDK ? 'sdk-' : '') + 'v' + version + '-osx-' + process.arch + '.zip';
     break;
   case 'linux':
-    url = urlBase + version + '/nwjs-v' + version + '-linux-' + process.arch + '.tar.gz';
+    url = urlBase + version + '/nwjs-' + (buildSDK ? 'sdk-' : '') + 'v' + version + '-linux-' + process.arch + '.tar.gz';
     break;
 }
 


### PR DESCRIPTION
The fourth alpha version of NW.js v0.13.0 is the first ever version to contain Node 4.x and thus it is especially important to support it in `npm-installer`.

NW.js v0.13.0 comes in several flavours: normal build, SDK build, NaCl build. Only the SDK build contains devtools and thus `npm-installer` should be able to install SDK build instead of a normal build where necessary.

This pull request suggests that the flavour prefix should be added directly to the version number (such as `0.13.0-alpha4sdk` instead of a mere `0.13.0-alpha4` in this pull request) and that `scripts/install.js` is changed to detect such prefix and it rewrites download URLs accordingly.