### PR TITLE
install NW.js v0.13.0 alpha 5 SDK build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw",
-  "version": "0.13.0-alpha4sdk",
+  "version": "0.13.0-alpha5sdk",
   "description": "A installer for nw.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
NW.js v0.13.0 alpha 5 [is released](https://groups.google.com/d/msg/nwjs-general/YuwMHd_uvPM/pLFWG3vYBwAJ) (with Chromium 46 and Node.js 5.0.0), and thus I am upgrading the effect of #30.