### PR TITLE
nw.js's code is https://github.com/nwjs/nw.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ export http_proxy="http://myproxy.com:8080"
 ```
 
 ## license
-[nw.js](https://github.com/rogerwang/nw.js)'s code and this installer use the MIT license.
+[nw.js](https://github.com/nwjs/nw.js)'s code and this installer use the MIT license.


### PR DESCRIPTION
The address https://github.com/rogerwang/nw.js (404 error) is replaced with https://github.com/nwjs/nw.js and it fixes #33.