### PR TITLE
update download library version with minor API changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "decompress": "^3.0.0",
-    "download": "^4.4.3",
+    "download": "^5.0.3",
     "file-exists": "^2.0.0",
     "merge": "^1.2.0",
     "multimeter": "^0.1.1",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var Download = require('download');
+var download = require('download');
 var rimraf = require('rimraf');
 var semver = require('semver');
 var createBar = require('multimeter')(process);
@@ -101,8 +101,7 @@ if( parsedUrl.protocol == 'file:' ) {
     .use( Decompress.targz(decompressOptions) )
     .run( cb );
 } else {
-  new Download(merge({ extract: true }, decompressOptions))
-    .get( url )
-    .dest( dest )
-    .run( cb );
+  download(url, dest, merge({ extract: true }, decompressOptions))
+    .then(function() {cb();})
+    .catch(function(e) {cb(e);});
 }


### PR DESCRIPTION
download@4.4.3 has issue with symlinks due to its internal version of gulp-decompress@1.2.0(=decompress@3.0.0). This is already fixed with the newer version(>=4.0.0) and simply updating this library will solve the symlink issue. My PR is to use download@5.0.3 which contains decompress@4.0.0.

*Please note this PR only contains minimal change for download issue and not touching the part for file protocol where our own decompress library is used which might contain the same issue. Probably someone wants to update that part too.