### PR TITLE
Feature: download progress bar on install script.

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -102,7 +102,15 @@ if( parsedUrl.protocol == 'file:' ) {
     .use( Decompress.targz(decompressOptions) )
     .run( cb );
 } else {
+  var progress = { total: null, downloaded: 0,
+    start: function(resp) { this.total = parseInt(resp.headers['content-length']); },
+    recvd: function(chunk) { 
+      this.downloaded += chunk.length; if (this.total) bar.ratio(this.downloaded, this.total);
+    }
+  };
   download(url, dest, merge({ extract: true }, decompressOptions))
+    .on('response', function(resp)  { progress.start(resp); })
+    .on('data',     function(chunk) { progress.recvd(chunk); })
     .then(function() {cb();})
     .catch(function(e) {cb(e);});
 }


### PR DESCRIPTION
Having encountered #26 and seeing that others keep hitting the same "huh?!", I suggest having indication that the script is downloading the ~100MB of NWjs.

Some preparation seems to have existed, in the form of `createBar(...)`. I plugged into this. Since progress only makes sense for download, I placed the vars for total and downloaded bytes in the HTTP-install conditional branch. Some global vars may become redundant (these were not used before either).