### PR TITLE
Add option for platform override

### DIFF
--- a/lib/findpath.js
+++ b/lib/findpath.js
@@ -4,13 +4,14 @@ var bindir = path.resolve(__dirname, '..', 'nwjs');
 
 module.exports = function() {
   var bin = bindir;
-  if (process.platform === 'darwin') {
+  var platform = process.env.npm_config_nwjs_platform || process.env.NWJS_PLATFORM || process.platform;
+  if (platform === 'darwin') {
     if (fs.existsSync(path.join(bin, 'Contents'))) {
       bin = path.join(bin, 'Contents', 'MacOS', 'nwjs');
     } else {
       bin = path.join(bin, 'nwjs.app', 'Contents', 'MacOS', 'nwjs');
     }
-  } else if (process.platform === 'win32') {
+  } else if (platform === 'win32') {
     bin = path.join(bin, 'nw.exe');
   } else {
     bin = path.join(bin, 'nw');

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -36,9 +36,10 @@ var url = false;
 var arch = process.env.npm_config_nwjs_process_arch || process.arch;
 var urlBase = process.env.npm_config_nwjs_urlbase || process.env.NWJS_URLBASE ||  'https://dl.nwjs.io/v';
 var buildTypeSuffix = buildType === 'normal' ? '' : ('-' + buildType);
+var platform = process.env.npm_config_nwjs_platform || process.env.NWJS_PLATFORM || process.platform;
 
 // Determine download url
-switch (process.platform) {
+switch (platform) {
   case 'win32':
     url = urlBase + version + '/nwjs' + buildTypeSuffix + '-v' + version + '-win-' + arch +'.zip';
     break;


### PR DESCRIPTION
Add the option to override the platform. Useful for cross-platform development or in situations where you are working on Windows in WSL and still want to execute via npm scripts.