### PR TITLE
Bump `download` vendor package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "chalk": "~1.1.3",
     "decompress": "^4.2.0",
-    "download": "^5.0.3",
+    "download": "^8.0.0",
     "file-exists": "^2.0.0",
     "merge": "^1.2.0",
     "multimeter": "^0.1.1",


### PR DESCRIPTION
The download vendor package has dependency for minimist which contains a security vulnerability. This commit bumps version to the latest in which the bug is fixed.