### PR TITLE
Download progress bar using `progress`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "download": "^5.0.3",
     "file-exists": "^2.0.0",
     "merge": "^1.2.0",
-    "multimeter": "^0.1.1",
+    "progress": "^2.0.3",
     "rimraf": "^2.2.8",
     "semver": "^5.1.0",
     "yargs": "^3.2.1"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -103,20 +103,35 @@ if( parsedUrl.protocol == 'file:' ) {
     .use( Decompress.targz(decompressOptions) )
     .run( cb );
 } else {
-  var progress = { total: null, downloaded: 0,
-     start: function(resp) {
-         this.total = parseInt(resp.headers['content-length']);
-         bar.total = Math.max(1, this.total / 1e6).toFixed(2);
-     },
-     recvd: function(chunk) {
-       this.downloaded += chunk.length;
-       if (this.total) { bar.update(this.downloaded / this.total); }
-     }
-   };
-   download(url, dest, merge({ extract: true }, decompressOptions))
-    .on('response', function(resp)  { progress.start(resp); })
-    .on('data',     function(chunk) { progress.recvd(chunk); })
-    .on('end',      function()      { bar.terminate(); })
-    .then(function() {cb();})
-    .catch(function(e) {cb(e);});
+  var progress = {
+    total: null,
+    downloaded: 0,
+    start: function (response) {
+      this.total = parseInt(response.headers['content-length']);
+      bar.total = (this.total / 1000000).toFixed(2);
+    },
+    recieved: function (chunk) {
+      this.downloaded += chunk.length;
+      if (this.total) {
+        bar.update(this.downloaded / this.total);
+      }
+    }
+  };
+
+  download(url, dest, merge({ extract: true }, decompressOptions))
+    .on('response', function (response) {
+      progress.start(response);
+    })
+    .on('data', function (chunk) {
+      progress.recieved(chunk);
+    })
+    .on('end', function () {
+      bar.terminate();
+    })
+    .then(function () {
+      cb();
+    })
+    .catch(function (err) {
+      cb(err);
+    });
 }


### PR DESCRIPTION
Having encountered #26 and seeing that others keep hitting the same "huh?!", I suggest having indication that the script is downloading the ~160MB of NWjs.

Some preparation seems to have existed, in the form of `createBar(...)` (using `multimeter`). It seems to be a rather outdated package, and does not take into account the width of the terminal. I replaced it with the more standard `progress`. Upgrading `download` is required for receiving the `downloadProgress` events.

(This PR replaces https://github.com/nwjs/npm-installer/pull/69.)