### PR TITLE
Test on maintaince, LTS and current versions of node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,15 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        node: [16, 18, 20]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
-      - name: Get Node version from Node manifest
-        run: |
-          echo "NODE_VER=$(jq -r '.engines.node' package.json | sed 's/v//' )" >> $GITHUB_ENV
       - uses: actions/setup-node@v3.6.0
         with:
-          node-version: ${{ env.NODE_VER }}
+          node-version: ${{ matrix.node }}
           cache: "npm"
       - name: Enable corepack
         run: corepack enable

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,6 @@
       },
       "devDependencies": {
         "request": "^2.53.0"
-      },
-      "engines": {
-        "node": "v20.5.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "postinstall": "node scripts/install.js",
-    "test": "node --test-reporter=spec --test test/index.mjs"
+    "test": "node --test test/index.mjs"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
   "devDependencies": {
     "request": "^2.53.0"
   },
-  "engines": {
-    "node": "v20.5.0"
-  },
   "packageManager": "npm@9.8.1",
   "keywords": [
     "nw",


### PR DESCRIPTION
For any Node version, one should be able to reliably download NW.js at least 2 major versions before. For example, NW 78 which has Node 20 should also download on Node 16 and 18. Thoughts @TheJaredWilcurt?