### PR TITLE
Do not pin Node version in `package.json`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "github-actions"
-    directory: ".github/"
+    directory: ".github/workflows"
     schedule:
       interval: "weekly"
       day: "saturday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "."
+    directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-    groups:
-      npm:
-        patterns:
-          - "*"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-    groups:
-      gha:
-        patterns:
-          - "*"
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "."
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+    groups:
+      npm:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: ".github/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+    groups:
+      gha:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,16 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.3.0
+      - name: Get Node version from Node manifest
+        run: |
+          echo "NODE_VER=$(jq -r '.engines.node' package.json | sed 's/v//' )" >> $GITHUB_ENV
+      - uses: actions/setup-node@v3.6.0
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "latest"
+          node-version: ${{ env.NODE_VER }}
           cache: "npm"
       - name: Enable corepack
         run: corepack enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
       - name: Get Node version from Node manifest
         run: |
           echo "NODE_VER=$(jq -r '.engines.node' package.json | sed 's/v//' )" >> $GITHUB_ENV
       - uses: actions/setup-node@v3.6.0
-      - name: Checkout repository
-        uses: actions/checkout@v3.3.0
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Get Node version from Node manifest
         run: |
           echo "NODE_VER=$(jq -r '.engines.node' package.json | sed 's/v//' )" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3.6.0
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
       - name: Get Node version from Node manifest
-        run: |
-          echo "NODE_VER=$(jq -r '.engines.node' package.json | sed 's/v//' )" >> $GITHUB_ENV
+        run: echo "NODE_VER=$(curl -s https://nwjs.io/versions | jq -r ".versions[0].components.node")" >> $GITHUB_ENV
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
-      - name: Get Node version from Node manifest
-        run: |
-          echo "NODE_VER=$(jq -r '.engines.node' package.json | sed 's/v//' )" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3.6.0
+      - name: Setup Node
+        uses: actions/setup-node@v3.6.0
         with:
-          node-version: ${{ env.NODE_VER }}
+          node-version: "latest"
           cache: "npm"
       - name: Enable corepack
         run: corepack enable

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   "devDependencies": {
     "request": "^2.53.0"
   },
+  "engines": {
+    "node": "v20.5.0"
+  },
   "packageManager": "npm@10.1.0",
   "keywords": [
     "nw",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "request": "^2.53.0"
   },
   "engines": {
-    "node": ">= 20.5.0"
+    "node": ">= 20.5.0 || >= 18.18.0"
   },
   "packageManager": "npm@10.1.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "request": "^2.53.0"
   },
   "engines": {
-    "node": "v20.5.0"
+    "node": ">= 20.5.0"
   },
   "packageManager": "npm@10.1.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -36,10 +36,7 @@
   "devDependencies": {
     "request": "^2.53.0"
   },
-  "engines": {
-    "node": "v20.5.0"
-  },
-  "packageManager": "npm@9.8.1",
+  "packageManager": "npm@10.1.0",
   "keywords": [
     "nw",
     "nw.js",


### PR DESCRIPTION
Refs: https://github.com/MaibornWolff/codecharta/pull/3362#issuecomment-1720740502

The PR linked above fails since `engine-strict` is set to `true`. Did not take this into account when I hardcoded the Node version.

## Changes

- Do not pin Node dependency
- Allow installing NW.js on LTS Node version (get Node version from `https://nwjs.io/versions` instead)

cc @TheJaredWilcurt 