### PR TITLE
ci: set up npm publish workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,22 @@
+name: cd
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  npm:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+      - name: Publish sdk tag to npm 
+        uses: JS-DevTools/npm-publish@v3.0.1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: sdk
+      - name: Publish latest tag to npm 
+        uses: JS-DevTools/npm-publish@v3.0.1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,15 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  e2e:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4.1.1
       - name: Get Node version from Node manifest
         run: echo "NODE_VER=$(curl -s https://nwjs.io/versions | jq -r ".versions[0].components.node")" >> $GITHUB_ENV
       - name: Setup Node
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: ${{ env.NODE_VER }}
           cache: "npm"
@@ -23,3 +23,18 @@ jobs:
         run: npm ci
       - name: Run test
         run: npm test
+  npm:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Test publish sdk tag to npm
+        uses: JS-DevTools/npm-publish@v3.0.1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: sdk
+          dry-run: true
+      - name: Test publish latest tag to npm
+        uses: JS-DevTools/npm-publish@v3.0.1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: latest
+          dry-run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
   npm:
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
       - name: Test publish sdk tag to npm
         uses: JS-DevTools/npm-publish@v3.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-22.04

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nw",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nw",
-      "version": "0.80.0",
+      "version": "0.81.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "A installer for nw.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes: #120
Closes: #119 (`NPM_TOKEN` is not recognised via forked repo)

### Changes

- Added `JS-DevTools/npm-publish` Action
- Publish to npm by changing version in `package.json`
- Test npm publish in PRs by enabling `--dry-run` option