### PR TITLE
Fix: ESM CJS Interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,20 @@ You may use the environment variable `npm_config_nwjs_process_arch` to override
 ## finding the path to the nw.js binary
 
 If you would like to programmatically retrieve the path to the nw.js binary use:
-
+### CJS
 ``` js
 var findpath = require('nw').findpath;
+var nwpath = findpath();
+// nwpath will equal the path to the binary depending on your environment
+```
+
+### ESM
+``` js
+// using Syntactic default import behavior
+import findpath from 'nw';
+// Without Syntatcatic
+import { default as findpath } from 'nw';
+
 var nwpath = findpath();
 // nwpath will equal the path to the binary depending on your environment
 ```

--- a/bin/nw
+++ b/bin/nw
@@ -48,8 +48,7 @@ async function run() {
 
 if (!fs.existsSync(bin)) {
   console.log('nw.js appears to have failed to download and extract. Attempting to download and extract again...');
-  var child = spawn(process.execPath, [path.resolve(__dirname, '..', 'scripts', 'install.mjs')], { stdio: 'inherit' });
-  child.on('close', run);
+  import('../lib/install').then(M=>M.install()).then(run);
 } else {
   run();
 }

--- a/bin/nw
+++ b/bin/nw
@@ -3,9 +3,10 @@
 var fs = require('fs');
 var path = require('path');
 var spawn = require('child_process').spawn;
-var bin = require('../lib/findpath.js')();
 
-function run() {
+
+async function run() {
+  var bin = await import('../lib/findpath.mjs').then((M)=>M.default());
   // Rename nw.js's own package.json as workaround for https://github.com/nwjs/nw.js/issues/1503
   var packagejson = path.resolve(__dirname, '..', 'package.json');
   var packagejsonBackup = path.resolve(__dirname, '..', 'package_backup.json');
@@ -47,7 +48,7 @@ function run() {
 
 if (!fs.existsSync(bin)) {
   console.log('nw.js appears to have failed to download and extract. Attempting to download and extract again...');
-  var child = spawn(process.execPath, [path.resolve(__dirname, '..', 'scripts', 'install.js')], { stdio: 'inherit' });
+  var child = spawn(process.execPath, [path.resolve(__dirname, '..', 'scripts', 'install.mjs')], { stdio: 'inherit' });
   child.on('close', run);
 } else {
   run();

--- a/lib/findpath.js
+++ b/lib/findpath.js
@@ -1,0 +1,1 @@
+exports.findpath = () => require('node:child_process').execSync('node -p '+ __dirname + '/findpath.mjs').slice(0,-1).trim();

--- a/lib/findpath.mjs
+++ b/lib/findpath.mjs
@@ -53,6 +53,6 @@ export default function findpath(executable = 'nwjs') {
   } else {
     console.error(`[ ERROR ] Expected nwjs or chromedriver, got ${executable}.`);
   }
-
+  console.log(binPath);
   return binPath;
 }

--- a/lib/install.mjs
+++ b/lib/install.mjs
@@ -11,9 +11,7 @@ import semver from 'semver';
 
 import nodeManifest from '../package.json' assert { type: 'json' };
 
-await install();
-
-async function install() {
+export async function install() {
 
   const PLATFORM_KV = {
     darwin: 'osx',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "type": "git",
     "url": "git://github.com/nwjs/npm-installer.git"
   },
-  "main": "lib/findpath.mjs",
+  "main": "lib/findpath.js",
+  "module": "lib/findpath.mjs",
   "bin": {
     "nw": "bin/nw"
   },


### PR DESCRIPTION
The binary in /bin is using CJS syntax and the files got renamed and converted to ESM so i fixed it via fixing the imports also i optimized the install prozess a bit.